### PR TITLE
Add functions for replicate, publish and deprecate

### DIFF
--- a/aliyun_img_utils/aliyun_cli.py
+++ b/aliyun_img_utils/aliyun_cli.py
@@ -405,11 +405,11 @@ def replicate(context, image_name, regions, **kwargs):
             regions = regions.split(',')
             keyword_args['regions'] = regions
 
-        aliyun_image.replicate_image(image_name, **keyword_args)
+        images = aliyun_image.replicate_image(image_name, **keyword_args)
 
     if config_data.log_level != logging.ERROR:
         echo_style(
-            f'Image replicated: {image_name}',
+            json.dumps(images, indent=2),
             config_data.no_color
         )
 
@@ -422,6 +422,12 @@ def replicate(context, image_name, regions, **kwargs):
     required=True
 )
 @click.option(
+    '--launch-permission',
+    type=click.STRING,
+    help='The launch permission to set for the published image.',
+    required=True
+)
+@click.option(
     '--regions',
     help='A comma separated list of region ids to '
          'publish the provided image in. If no regions '
@@ -430,7 +436,7 @@ def replicate(context, image_name, regions, **kwargs):
 )
 @add_options(shared_options)
 @click.pass_context
-def publish(context, image_name, regions, **kwargs):
+def publish(context, image_name, launch_permission, regions, **kwargs):
     """
     Publish a compute image in a set of regions.
 
@@ -457,7 +463,11 @@ def publish(context, image_name, regions, **kwargs):
             regions = regions.split(',')
             keyword_args['regions'] = regions
 
-        aliyun_image.publish_image_to_regions(image_name, **keyword_args)
+        aliyun_image.publish_image_to_regions(
+            image_name,
+            launch_permission,
+            **keyword_args
+        )
 
     if config_data.log_level != logging.ERROR:
         echo_style(

--- a/aliyun_img_utils/aliyun_image.py
+++ b/aliyun_img_utils/aliyun_image.py
@@ -40,6 +40,15 @@ from aliyunsdkecs.request.v20140526.DescribeImagesRequest import (
 from aliyunsdkecs.request.v20140526.DescribeRegionsRequest import (
     DescribeRegionsRequest
 )
+from aliyunsdkecs.request.v20140526.CopyImageRequest import (
+    CopyImageRequest
+)
+from aliyunsdkecs.request.v20140526.ModifyImageSharePermissionRequest import (
+    ModifyImageSharePermissionRequest
+)
+from aliyunsdkecs.request.v20140526.ModifyImageAttributeRequest import (
+    ModifyImageAttributeRequest
+)
 
 from aliyun_img_utils.aliyun_exceptions import (
     AliyunException,
@@ -191,11 +200,18 @@ class AliyunImage(object):
 
         if delete_blob:
             device = image['DiskDeviceMappings']['DiskDeviceMapping'][0]
-            self.delete_storage_blob(device['ImportOSSObject'])
+
+            if 'ImportOSSObject' in device:
+                self.delete_storage_blob(device['ImportOSSObject'])
 
         return True
 
-    def get_compute_image(self, image_name=None, image_id=None):
+    def get_compute_image(
+        self,
+        image_name=None,
+        image_id=None,
+        is_deprecated=False
+    ):
         """
         Return compute image by name and/or id.
 
@@ -205,7 +221,7 @@ class AliyunImage(object):
         """
         if not image_name and not image_id:
             raise AliyunImageException(
-                'Image name and/or image id is required to get image.'
+                'Image name and/or image ID is required to get image.'
             )
 
         request = DescribeImagesRequest()
@@ -216,6 +232,9 @@ class AliyunImage(object):
 
         if image_id:
             request.set_ImageId(image_id)
+
+        if is_deprecated:
+            request.set_Status('Deprecated')
 
         try:
             response = json.loads(
@@ -336,6 +355,179 @@ class AliyunImage(object):
         self.wait_on_compute_image(response['ImageId'])
 
         return response['ImageId']
+
+    def copy_compute_image(self, source_image_name, destination_region):
+        """
+        Copy compute image to specified region.
+        """
+        image = self.get_compute_image(image_name=source_image_name)
+
+        request = CopyImageRequest()
+        request.set_accept_format('json')
+        request.set_ImageId(image['ImageId'])
+        request.set_DestinationImageName(source_image_name)
+        request.set_DestinationDescription(image['Description'])
+        request.set_DestinationRegionId(destination_region)
+
+        try:
+            response = json.loads(
+                self.compute_client.do_action_with_exception(request)
+            )
+        except Exception as error:
+            raise AliyunImageException(
+                f'Unable to copy image: {error}.'
+            )
+
+        return response['ImageId']
+
+    def replicate_image(self, source_image_name, regions=None):
+        """
+        Copy the compute image based on image name to all regions.
+
+        If a region list is not provided use all available regions.
+        """
+        if not regions:
+            regions = self.get_regions()
+
+        for region in regions:
+            if region == self.region:
+                continue
+
+            image_id = None
+            try:
+                image_id = self.copy_compute_image(source_image_name, region)
+            except Exception as error:
+                self.log.error(
+                    f'Failed to copy {source_image_name} to {region}: '
+                    f'{error}.'
+                )
+            else:
+                self.log.info(f'{image_id} created in {region}')
+
+    def publish_image(self, source_image_name):
+        """
+        Publish compute image in current region.
+        """
+        image = self.get_compute_image(image_name=source_image_name)
+
+        request = ModifyImageSharePermissionRequest()
+        request.set_accept_format('json')
+        request.set_ImageId(image['ImageId'])
+        request.set_LaunchPermission('HIDDEN')
+
+        try:
+            self.compute_client.do_action_with_exception(request)
+        except Exception as error:
+            raise AliyunImageException(
+                f'Unable to publish image: {error}.'
+            )
+
+    def publish_image_to_regions(self, source_image_name, regions=None):
+        """
+        Publish the compute image based on image name in all regions.
+
+        If a region list is not provided use all available regions.
+        """
+        if not regions:
+            regions = self.get_regions()
+
+        for region in regions:
+            self.region = region
+
+            try:
+                self.publish_image(source_image_name)
+            except Exception as error:
+                self.log.error(
+                    f'Failed to publish {source_image_name} in {region}: '
+                    f'{error}.'
+                )
+            else:
+                self.log.info(f'{source_image_name} published in {region}')
+
+    def deprecate_image(self, source_image_name):
+        """
+        Deprecate compute image in current region.
+        """
+        image = self.get_compute_image(image_name=source_image_name)
+
+        request = ModifyImageAttributeRequest()
+        request.set_accept_format('json')
+        request.set_ImageId(image['ImageId'])
+        request.set_Status('Deprecated')
+
+        try:
+            self.compute_client.do_action_with_exception(request)
+        except Exception as error:
+            raise AliyunImageException(
+                f'Unable to deprecate image: {error}.'
+            )
+
+    def deprecate_image_in_regions(self, source_image_name, regions=None):
+        """
+        Deprecate the compute image based on image name in all regions.
+
+        If a region list is not provided use all available regions.
+        """
+        if not regions:
+            regions = self.get_regions()
+
+        for region in regions:
+            self.region = region
+
+            try:
+                self.deprecate_image(source_image_name)
+            except Exception as error:
+                self.log.error(
+                    f'Failed to deprecate {source_image_name} in {region}: '
+                    f'{error}.'
+                )
+            else:
+                self.log.info(f'{source_image_name} deprecated in {region}')
+
+    def activate_image(self, source_image_name):
+        """
+        Activate compute image in current region.
+
+        Sets the image status to available from a deprecated state.
+        """
+        image = self.get_compute_image(
+            image_name=source_image_name,
+            is_deprecated=True
+        )
+
+        request = ModifyImageAttributeRequest()
+        request.set_accept_format('json')
+        request.set_ImageId(image['ImageId'])
+        request.set_Status('Available')
+
+        try:
+            self.compute_client.do_action_with_exception(request)
+        except Exception as error:
+            raise AliyunImageException(
+                f'Unable to activate image: {error}.'
+            )
+
+    def activate_image_in_regions(self, source_image_name, regions=None):
+        """
+        Activate compute image in all regions.
+
+        If a region list is not provided use all available regions.
+        """
+        if not regions:
+            regions = self.get_regions()
+
+        for region in regions:
+            self.region = region
+
+            try:
+                self.activate_image(source_image_name)
+            except Exception as error:
+                self.log.error(
+                    f'Failed to activate {source_image_name} in {region}: '
+                    f'{error}.'
+                )
+            else:
+                self.log.info(f'{source_image_name} activated in {region}')
 
     @property
     def bucket_client(self):

--- a/tests/test_aliyun_image.py
+++ b/tests/test_aliyun_image.py
@@ -299,7 +299,7 @@ class TestAliyunImage(object):
         client.do_action_with_exception.return_value = response
         self.image._compute_client = client
 
-        self.image.publish_image_to_regions('test-image')
+        self.image.publish_image_to_regions('test-image', 'VISIBLE')
 
     @patch.object(AliyunImage, 'get_compute_image')
     def test_publish_image(self, mock_get_image):
@@ -311,12 +311,12 @@ class TestAliyunImage(object):
         client.do_action_with_exception.return_value = response
         self.image._compute_client = client
 
-        self.image.publish_image('test-image')
+        self.image.publish_image('test-image', 'VISIBLE')
 
         # Publish failure
         client.do_action_with_exception.side_effect = Exception
         with raises(AliyunImageException):
-            self.image.publish_image('test-image')
+            self.image.publish_image('test-image', 'VISIBLE')
 
     @patch.object(AliyunImage, 'deprecate_image')
     @patch.object(AliyunImage, 'get_regions')

--- a/tests/test_aliyun_image.py
+++ b/tests/test_aliyun_image.py
@@ -262,3 +262,132 @@ class TestAliyunImage(object):
         self.image.region = 'cn-beijing'
         assert self.image._bucket_client is None
         assert self.image._compute_client is None
+
+    @patch.object(AliyunImage, 'get_regions')
+    @patch.object(AliyunImage, 'get_compute_image')
+    def test_replicate_image(self, mock_get_image, mock_get_regions):
+        image = {'ImageId': 'm-123', 'Description': 'Test image'}
+        response = json.dumps(image)
+        mock_get_image.return_value = image
+        mock_get_regions.return_value = ['cn-shanghai']
+
+        client = Mock()
+        client.do_action_with_exception.return_value = response
+        self.image._compute_client = client
+
+        self.image.replicate_image('test-image')
+
+        # Replicate failure
+        client.do_action_with_exception.side_effect = Exception
+        self.image.replicate_image('test-image')
+
+    @patch.object(AliyunImage, 'publish_image')
+    @patch.object(AliyunImage, 'get_regions')
+    @patch.object(AliyunImage, 'get_compute_image')
+    def test_publish_image_to_regions(
+        self,
+        mock_get_image,
+        mock_get_regions,
+        mock_publish_image
+    ):
+        image = {'ImageId': 'm-123'}
+        response = json.dumps(image)
+        mock_get_image.return_value = image
+        mock_get_regions.return_value = ['cn-beijing']
+
+        client = Mock()
+        client.do_action_with_exception.return_value = response
+        self.image._compute_client = client
+
+        self.image.publish_image_to_regions('test-image')
+
+    @patch.object(AliyunImage, 'get_compute_image')
+    def test_publish_image(self, mock_get_image):
+        image = {'ImageId': 'm-123'}
+        response = json.dumps(image)
+        mock_get_image.return_value = image
+
+        client = Mock()
+        client.do_action_with_exception.return_value = response
+        self.image._compute_client = client
+
+        self.image.publish_image('test-image')
+
+        # Publish failure
+        client.do_action_with_exception.side_effect = Exception
+        with raises(AliyunImageException):
+            self.image.publish_image('test-image')
+
+    @patch.object(AliyunImage, 'deprecate_image')
+    @patch.object(AliyunImage, 'get_regions')
+    @patch.object(AliyunImage, 'get_compute_image')
+    def test_deprecate_image_in_regions(
+        self,
+        mock_get_image,
+        mock_get_regions,
+        mock_deprecate_image
+    ):
+        image = {'ImageId': 'm-123'}
+        response = json.dumps(image)
+        mock_get_image.return_value = image
+        mock_get_regions.return_value = ['cn-beijing']
+
+        client = Mock()
+        client.do_action_with_exception.return_value = response
+        self.image._compute_client = client
+
+        self.image.deprecate_image_in_regions('test-image')
+
+    @patch.object(AliyunImage, 'get_compute_image')
+    def test_deprecate_image(self, mock_get_image):
+        image = {'ImageId': 'm-123'}
+        response = json.dumps(image)
+        mock_get_image.return_value = image
+
+        client = Mock()
+        client.do_action_with_exception.return_value = response
+        self.image._compute_client = client
+
+        self.image.deprecate_image('test-image')
+
+        # Deprecate failure
+        client.do_action_with_exception.side_effect = Exception
+        with raises(AliyunImageException):
+            self.image.deprecate_image('test-image')
+
+    @patch.object(AliyunImage, 'activate_image')
+    @patch.object(AliyunImage, 'get_regions')
+    @patch.object(AliyunImage, 'get_compute_image')
+    def test_activate_image_in_regions(
+        self,
+        mock_get_image,
+        mock_get_regions,
+        mock_activate_image
+    ):
+        image = {'ImageId': 'm-123'}
+        response = json.dumps(image)
+        mock_get_image.return_value = image
+        mock_get_regions.return_value = ['cn-beijing']
+
+        client = Mock()
+        client.do_action_with_exception.return_value = response
+        self.image._compute_client = client
+
+        self.image.activate_image_in_regions('test-image')
+
+    @patch.object(AliyunImage, 'get_compute_image')
+    def test_activate_image(self, mock_get_image):
+        image = {'ImageId': 'm-123'}
+        response = json.dumps(image)
+        mock_get_image.return_value = image
+
+        client = Mock()
+        client.do_action_with_exception.return_value = response
+        self.image._compute_client = client
+
+        self.image.activate_image('test-image')
+
+        # Activate failure
+        client.do_action_with_exception.side_effect = Exception
+        with raises(AliyunImageException):
+            self.image.activate_image('test-image')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,6 +128,10 @@ def test_cli_exception(mock_img_class):
 @patch('aliyun_img_utils.aliyun_cli.AliyunImage')
 def test_cli_replicate_image(mock_img_class):
     image_class = MagicMock()
+    image_class.replicate_image.return_value = {
+        'cn-beijing': 'ami-123',
+        'cn-shanghai': 'ami-321'
+    }
     mock_img_class.return_value = image_class
 
     args = [
@@ -138,7 +142,7 @@ def test_cli_replicate_image(mock_img_class):
     runner = CliRunner()
     result = runner.invoke(main, args)
     assert result.exit_code == 0
-    assert 'Image replicated' in result.output
+    assert 'ami-123' in result.output
 
 
 @patch('aliyun_img_utils.aliyun_cli.AliyunImage')
@@ -148,7 +152,8 @@ def test_cli_publish_image(mock_img_class):
 
     args = [
         'image', 'publish', '--image-name', 'test-image',
-        '--regions', 'cn-beijing,cn-shanghai'
+        '--launch-permission', 'HIDDEN', '--regions',
+        'cn-beijing,cn-shanghai'
     ]
 
     runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,3 +123,67 @@ def test_cli_exception(mock_img_class):
     result = runner.invoke(main, args)
     assert result.exit_code == 1
     assert 'Failure!' in result.output
+
+
+@patch('aliyun_img_utils.aliyun_cli.AliyunImage')
+def test_cli_replicate_image(mock_img_class):
+    image_class = MagicMock()
+    mock_img_class.return_value = image_class
+
+    args = [
+        'image', 'replicate', '--image-name', 'test-image',
+        '--regions', 'cn-beijing,cn-shanghai'
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(main, args)
+    assert result.exit_code == 0
+    assert 'Image replicated' in result.output
+
+
+@patch('aliyun_img_utils.aliyun_cli.AliyunImage')
+def test_cli_publish_image(mock_img_class):
+    image_class = MagicMock()
+    mock_img_class.return_value = image_class
+
+    args = [
+        'image', 'publish', '--image-name', 'test-image',
+        '--regions', 'cn-beijing,cn-shanghai'
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(main, args)
+    assert result.exit_code == 0
+    assert 'Image published' in result.output
+
+
+@patch('aliyun_img_utils.aliyun_cli.AliyunImage')
+def test_cli_deprecate_image(mock_img_class):
+    image_class = MagicMock()
+    mock_img_class.return_value = image_class
+
+    args = [
+        'image', 'deprecate', '--image-name', 'test-image',
+        '--regions', 'cn-beijing,cn-shanghai'
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(main, args)
+    assert result.exit_code == 0
+    assert 'Image deprecated' in result.output
+
+
+@patch('aliyun_img_utils.aliyun_cli.AliyunImage')
+def test_cli_activate_image(mock_img_class):
+    image_class = MagicMock()
+    mock_img_class.return_value = image_class
+
+    args = [
+        'image', 'activate', '--image-name', 'test-image',
+        '--regions', 'cn-beijing,cn-shanghai'
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(main, args)
+    assert result.exit_code == 0
+    assert 'Image activated' in result.output


### PR DESCRIPTION
- Add method to activate deprecated images
- Add option to get image by name or id.
- Add comments to CLI functions.
- Log error in helper methods instead of failing in on region.

@rjschwei sorry this grew bigger than planned. But most of the functions do pretty much the same thing with slightly different attrs.