### PR TITLE
Un-share image before deprecation

### DIFF
--- a/aliyun_img_utils/aliyun_cli.py
+++ b/aliyun_img_utils/aliyun_cli.py
@@ -519,6 +519,12 @@ def publish(context, image_name, launch_permission, regions, **kwargs):
     required=True
 )
 @click.option(
+    '--launch-permission',
+    type=click.STRING,
+    help='The launch permission to set for the deprecated image.',
+    required=True
+)
+@click.option(
     '--regions',
     help='A comma separated list of region ids to '
          'deprecate the provided image in. If no regions '
@@ -541,6 +547,7 @@ def publish(context, image_name, launch_permission, regions, **kwargs):
 def deprecate(
     context,
     image_name,
+    launch_permission,
     regions,
     replacement_image,
     deprecation_period,
@@ -576,7 +583,11 @@ def deprecate(
         if replacement_image:
             keyword_args['replacement_image'] = replacement_image
 
-        aliyun_image.deprecate_image_in_regions(image_name, **keyword_args)
+        aliyun_image.deprecate_image_in_regions(
+            image_name,
+            launch_permission,
+            **keyword_args
+        )
 
     if config_data.log_level != logging.ERROR:
         echo_style(

--- a/tests/test_aliyun_image.py
+++ b/tests/test_aliyun_image.py
@@ -329,6 +329,18 @@ class TestAliyunImage(object):
         with raises(AliyunImageException):
             self.image.publish_image('test-image', 'VISIBLE')
 
+    def test_unshare_image(self):
+        client = Mock()
+        client.do_action_with_exception.return_value = None
+        self.image._compute_client = client
+
+        self.image.unshare_image('m-123', 'FAKE')
+
+        # Deprecate failure
+        client.do_action_with_exception.side_effect = Exception
+        with raises(AliyunImageException):
+            self.image.unshare_image('m-123', 'FAKE')
+
     @patch.object(AliyunImage, 'deprecate_image')
     @patch.object(AliyunImage, 'get_regions')
     @patch.object(AliyunImage, 'get_compute_image')
@@ -347,11 +359,17 @@ class TestAliyunImage(object):
         client.do_action_with_exception.return_value = response
         self.image._compute_client = client
 
-        self.image.deprecate_image_in_regions('test-image')
+        self.image.deprecate_image_in_regions('test-image', 'FAKE')
 
+    @patch.object(AliyunImage, 'unshare_image')
     @patch.object(AliyunImage, 'add_image_tags')
     @patch.object(AliyunImage, 'get_compute_image')
-    def test_deprecate_image(self, mock_get_image, mock_add_tags):
+    def test_deprecate_image(
+        self,
+        mock_get_image,
+        mock_add_tags,
+        mock_unshare
+    ):
         image = {'ImageId': 'm-123'}
         response = json.dumps(image)
         mock_get_image.return_value = image
@@ -360,13 +378,14 @@ class TestAliyunImage(object):
         client.do_action_with_exception.return_value = response
         self.image._compute_client = client
 
-        self.image.deprecate_image('test-image')
+        self.image.deprecate_image('test-image', 'FAKE')
         assert mock_add_tags.call_count == 1
+        assert mock_unshare.call_count == 1
 
         # Deprecate failure
         client.do_action_with_exception.side_effect = Exception
         with raises(AliyunImageException):
-            self.image.deprecate_image('test-image')
+            self.image.deprecate_image('test-image', 'FAKE')
 
     @patch.object(AliyunImage, 'activate_image')
     @patch.object(AliyunImage, 'get_regions')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,7 +162,8 @@ def test_cli_deprecate_image(mock_img_class):
 
     args = [
         'image', 'deprecate', '--image-name', 'test-image',
-        '--regions', 'cn-beijing,cn-shanghai'
+        '--launch-permission', 'FAKE', '--regions',
+        'cn-beijing,cn-shanghai'
     ]
 
     runner = CliRunner()


### PR DESCRIPTION
The image is unshared via launch permission attr before it is deprecated.

Fixes #28 