### PR TITLE
Revert deprecate changes

### DIFF
--- a/aliyun_img_utils/aliyun_cli.py
+++ b/aliyun_img_utils/aliyun_cli.py
@@ -519,12 +519,6 @@ def publish(context, image_name, launch_permission, regions, **kwargs):
     required=True
 )
 @click.option(
-    '--launch-permission',
-    type=click.STRING,
-    help='The launch permission to set for the deprecated image.',
-    required=True
-)
-@click.option(
     '--regions',
     help='A comma separated list of region ids to '
          'deprecate the provided image in. If no regions '
@@ -547,7 +541,6 @@ def publish(context, image_name, launch_permission, regions, **kwargs):
 def deprecate(
     context,
     image_name,
-    launch_permission,
     regions,
     replacement_image,
     deprecation_period,
@@ -585,7 +578,6 @@ def deprecate(
 
         aliyun_image.deprecate_image_in_regions(
             image_name,
-            launch_permission,
             **keyword_args
         )
 

--- a/aliyun_img_utils/aliyun_image.py
+++ b/aliyun_img_utils/aliyun_image.py
@@ -560,65 +560,19 @@ class AliyunImage(object):
 
         return tags
 
-    def unshare_image(self, image_id, launch_permission):
-        """
-        Un-share compute image in current region.
-        """
-        request = ModifyImageSharePermissionRequest()
-        request.set_accept_format('json')
-        request.set_ImageId(image_id)
-        request.set_LaunchPermission(launch_permission)
-
-        try:
-            self.compute_client.do_action_with_exception(request)
-        except Exception as error:
-            self.log.error(
-                f'Failed to un-share {image_id} in {self.region}: '
-                f'{error}.'
-            )
-            raise AliyunImageException(
-                f'Failed to un-share image: {error}.'
-            )
-
-        self.log.info(f'{image_id} un-shared in {self.region}')
-
-    def deprecate_image(
-        self,
-        source_image_name,
-        launch_permission,
-        replacement_image=None
-    ):
+    def deprecate_image(self, source_image_name, replacement_image=None):
         """
         Deprecate compute image in current region.
         """
         image = self.get_compute_image(image_name=source_image_name)
-        self.unshare_image(image['ImageId'], launch_permission)
-
-        request = ModifyImageAttributeRequest()
-        request.set_accept_format('json')
-        request.set_ImageId(image['ImageId'])
-        request.set_Status('Deprecated')
-
-        try:
-            self.compute_client.do_action_with_exception(request)
-        except Exception as error:
-            self.log.error(
-                f'Failed to deprecate {source_image_name} in {self.region}: '
-                f'{error}.'
-            )
-            raise AliyunImageException(
-                f'Failed to deprecate image: {error}.'
-            )
-
         tags = self.generate_deprecation_tags(replacement_image)
-        self.add_image_tags(image['ImageId'], tags)
 
+        self.add_image_tags(image['ImageId'], tags)
         self.log.info(f'{source_image_name} deprecated in {self.region}')
 
     def deprecate_image_in_regions(
         self,
         source_image_name,
-        launch_permission,
         regions=None,
         replacement_image=None
     ):
@@ -636,7 +590,6 @@ class AliyunImage(object):
             try:
                 self.deprecate_image(
                     source_image_name,
-                    launch_permission,
                     replacement_image
                 )
             except Exception:

--- a/tests/test_aliyun_image.py
+++ b/tests/test_aliyun_image.py
@@ -335,18 +335,6 @@ class TestAliyunImage(object):
         with raises(AliyunImageException):
             self.image.publish_image('test-image', 'VISIBLE')
 
-    def test_unshare_image(self):
-        client = Mock()
-        client.do_action_with_exception.return_value = None
-        self.image._compute_client = client
-
-        self.image.unshare_image('m-123', 'FAKE')
-
-        # Deprecate failure
-        client.do_action_with_exception.side_effect = Exception
-        with raises(AliyunImageException):
-            self.image.unshare_image('m-123', 'FAKE')
-
     @patch.object(AliyunImage, 'deprecate_image')
     @patch.object(AliyunImage, 'get_regions')
     @patch.object(AliyunImage, 'get_compute_image')
@@ -365,33 +353,20 @@ class TestAliyunImage(object):
         client.do_action_with_exception.return_value = response
         self.image._compute_client = client
 
-        self.image.deprecate_image_in_regions('test-image', 'FAKE')
+        self.image.deprecate_image_in_regions('test-image')
 
-    @patch.object(AliyunImage, 'unshare_image')
     @patch.object(AliyunImage, 'add_image_tags')
     @patch.object(AliyunImage, 'get_compute_image')
     def test_deprecate_image(
         self,
         mock_get_image,
-        mock_add_tags,
-        mock_unshare
+        mock_add_tags
     ):
         image = {'ImageId': 'm-123'}
-        response = json.dumps(image)
         mock_get_image.return_value = image
 
-        client = Mock()
-        client.do_action_with_exception.return_value = response
-        self.image._compute_client = client
-
-        self.image.deprecate_image('test-image', 'FAKE')
+        self.image.deprecate_image('test-image')
         assert mock_add_tags.call_count == 1
-        assert mock_unshare.call_count == 1
-
-        # Deprecate failure
-        client.do_action_with_exception.side_effect = Exception
-        with raises(AliyunImageException):
-            self.image.deprecate_image('test-image', 'FAKE')
 
     @patch.object(AliyunImage, 'activate_image')
     @patch.object(AliyunImage, 'get_regions')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,8 +162,7 @@ def test_cli_deprecate_image(mock_img_class):
 
     args = [
         'image', 'deprecate', '--image-name', 'test-image',
-        '--launch-permission', 'FAKE', '--regions',
-        'cn-beijing,cn-shanghai'
+        '--regions', 'cn-beijing,cn-shanghai'
     ]
 
     runner = CliRunner()


### PR DESCRIPTION
Deprecation of an image consists only of adding deprecation tags.
The image remains available and shared.