### PR TITLE
Add alias command for unpublishing images

### DIFF
--- a/aliyun_img_utils/aliyun_cli.py
+++ b/aliyun_img_utils/aliyun_cli.py
@@ -498,7 +498,7 @@ def publish(context, image_name, launch_permission, regions, **kwargs):
             regions = regions.split(',')
             keyword_args['regions'] = regions
 
-        aliyun_image.publish_image_to_regions(
+        aliyun_image.set_launch_permission_in_regions(
             image_name,
             launch_permission,
             **keyword_args
@@ -507,6 +507,68 @@ def publish(context, image_name, launch_permission, regions, **kwargs):
     if config_data.log_level != logging.ERROR:
         echo_style(
             f'Image published: {image_name}',
+            config_data.no_color
+        )
+
+
+@click.command()
+@click.option(
+    '--image-name',
+    type=click.STRING,
+    help='Name of the image to be unpublished.',
+    required=True
+)
+@click.option(
+    '--launch-permission',
+    type=click.STRING,
+    help='The launch permission to set for the unpublished image.',
+    required=True
+)
+@click.option(
+    '--regions',
+    help='A comma separated list of region ids to '
+         'publish the provided image in. If no regions '
+         'are provided the image will be published in all '
+         'available regions.'
+)
+@add_options(shared_options)
+@click.pass_context
+def unpublish(context, image_name, launch_permission, regions, **kwargs):
+    """
+    Unpublish a compute image in a set of regions.
+
+    If no regions are provided the image is published to all
+    available regions.
+    """
+    process_shared_options(context.obj, kwargs)
+    config_data = get_config(context.obj)
+    logger = get_logger(config_data.log_level)
+
+    with handle_errors(config_data.log_level, config_data.no_color):
+        aliyun_image = AliyunImage(
+            config_data.access_key,
+            config_data.access_secret,
+            config_data.region,
+            config_data.bucket_name,
+            log_level=config_data.log_level,
+            log_callback=logger
+        )
+
+        keyword_args = {}
+
+        if regions:
+            regions = regions.split(',')
+            keyword_args['regions'] = regions
+
+        aliyun_image.set_launch_permission_in_regions(
+            image_name,
+            launch_permission,
+            **keyword_args
+        )
+
+    if config_data.log_level != logging.ERROR:
+        echo_style(
+            f'Image unpublished: {image_name}',
             config_data.no_color
         )
 
@@ -697,6 +759,7 @@ image.add_command(create)
 image.add_command(delete)
 image.add_command(deprecate)
 image.add_command(publish)
+image.add_command(unpublish)
 image.add_command(replicate)
 image.add_command(upload)
 image.add_command(info)

--- a/aliyun_img_utils/aliyun_image.py
+++ b/aliyun_img_utils/aliyun_image.py
@@ -486,7 +486,7 @@ class AliyunImage(object):
 
         return images
 
-    def publish_image(self, source_image_name, launch_permission):
+    def set_launch_permission(self, source_image_name, launch_permission):
         """
         Publish compute image in current region.
         """
@@ -501,16 +501,16 @@ class AliyunImage(object):
             self.compute_client.do_action_with_exception(request)
         except Exception as error:
             self.log.error(
-                f'Failed to publish {source_image_name} in {self.region}: '
-                f'{error}.'
+                f'Failed to set launch permission to {launch_permission} for'
+                f'{source_image_name} in {self.region}: {error}.'
             )
             raise AliyunImageException(
-                f'Failed to publish image: {error}.'
+                f'Failed to set launch permission: {error}.'
             )
 
-        self.log.info(f'{source_image_name} published in {self.region}')
+        self.log.info(f'{source_image_name} updated in {self.region}')
 
-    def publish_image_to_regions(
+    def set_launch_permission_in_regions(
         self,
         source_image_name,
         launch_permission,
@@ -528,7 +528,10 @@ class AliyunImage(object):
             self.region = region
 
             try:
-                self.publish_image(source_image_name, launch_permission)
+                self.set_launch_permission(
+                    source_image_name,
+                    launch_permission
+                )
             except Exception:
                 pass
 

--- a/tests/test_aliyun_image.py
+++ b/tests/test_aliyun_image.py
@@ -298,10 +298,10 @@ class TestAliyunImage(object):
         client.do_action_with_exception.side_effect = Exception
         self.image.replicate_image('test-image')
 
-    @patch.object(AliyunImage, 'publish_image')
+    @patch.object(AliyunImage, 'set_launch_permission')
     @patch.object(AliyunImage, 'get_regions')
     @patch.object(AliyunImage, 'get_compute_image')
-    def test_publish_image_to_regions(
+    def test_set_launch_permission_in_regions(
         self,
         mock_get_image,
         mock_get_regions,
@@ -316,10 +316,10 @@ class TestAliyunImage(object):
         client.do_action_with_exception.return_value = response
         self.image._compute_client = client
 
-        self.image.publish_image_to_regions('test-image', 'VISIBLE')
+        self.image.set_launch_permission_in_regions('test-image', 'VISIBLE')
 
     @patch.object(AliyunImage, 'get_compute_image')
-    def test_publish_image(self, mock_get_image):
+    def test_set_launch_permission(self, mock_get_image):
         image = {'ImageId': 'm-123'}
         response = json.dumps(image)
         mock_get_image.return_value = image
@@ -328,12 +328,12 @@ class TestAliyunImage(object):
         client.do_action_with_exception.return_value = response
         self.image._compute_client = client
 
-        self.image.publish_image('test-image', 'VISIBLE')
+        self.image.set_launch_permission('test-image', 'VISIBLE')
 
         # Publish failure
         client.do_action_with_exception.side_effect = Exception
         with raises(AliyunImageException):
-            self.image.publish_image('test-image', 'VISIBLE')
+            self.image.set_launch_permission('test-image', 'VISIBLE')
 
     @patch.object(AliyunImage, 'deprecate_image')
     @patch.object(AliyunImage, 'get_regions')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,6 +156,23 @@ def test_cli_publish_image(mock_img_class):
 
 
 @patch('aliyun_img_utils.aliyun_cli.AliyunImage')
+def test_cli_unpublish_image(mock_img_class):
+    image_class = MagicMock()
+    mock_img_class.return_value = image_class
+
+    args = [
+        'image', 'unpublish', '--image-name', 'test-image',
+        '--launch-permission', 'FAKE', '--regions',
+        'cn-beijing,cn-shanghai'
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(main, args)
+    assert result.exit_code == 0
+    assert 'Image unpublished' in result.output
+
+
+@patch('aliyun_img_utils.aliyun_cli.AliyunImage')
 def test_cli_deprecate_image(mock_img_class):
     image_class = MagicMock()
     mock_img_class.return_value = image_class


### PR DESCRIPTION
Rename class publish method to reference setting launch
permissions. This can then be used for publish and unpublish which
are currently aliases of each other.