### PR TITLE
Handle KeyError when getting image

### DIFF
--- a/aliyun_img_utils/aliyun_image.py
+++ b/aliyun_img_utils/aliyun_image.py
@@ -324,7 +324,7 @@ class AliyunImage(object):
 
         try:
             image = response['Images']['Image'][0]
-        except IndexError:
+        except (KeyError, IndexError):
             raise AliyunImageException(
                 'Unable to find image.'
             )


### PR DESCRIPTION
In case the response is not formatted as expected when an image has recently been created.