### PR TITLE
Use the connection timeout for compute client

### DIFF
--- a/aliyun_img_utils/aliyun_image.py
+++ b/aliyun_img_utils/aliyun_image.py
@@ -719,7 +719,8 @@ class AliyunImage(object):
                 self._compute_client = AcsClient(
                     self.access_key,
                     self.access_secret,
-                    self.region
+                    self.region,
+                    connect_timeout=self.timeout
                 )
             except Exception as error:
                 raise AliyunException(


### PR DESCRIPTION
Similar to the storage client.

This should limit the chances for connection timeout exceptions.