### PR TITLE
Better handling of image state in waiter

### DIFF
--- a/aliyun_img_utils/aliyun_cli.py
+++ b/aliyun_img_utils/aliyun_cli.py
@@ -652,19 +652,18 @@ def activate(context, image_name, regions, **kwargs):
     help='ID of the image.'
 )
 @click.option(
-    '--deprecated',
-    is_flag=True,
-    help='If set the search is filtered on images '
-         'in deprecated state.'
+    '--status',
+    type=click.Choice(AliyunImage.IMAGE_STATES),
+    help='The state of the image. By default the query '
+         'will include all states.'
 )
 @add_options(shared_options)
 @click.pass_context
-def info(context, image_name, image_id, deprecated, **kwargs):
+def info(context, image_name, image_id, status, **kwargs):
     """
     Get a dictionary of image data for an image based on ID or name.
 
-    If `--deprecated` all images in deprecated state are searched
-    otherwise all images in active state are searched.
+    The default status is all states.
     """
     process_shared_options(context.obj, kwargs)
     config_data = get_config(context.obj)
@@ -683,7 +682,7 @@ def info(context, image_name, image_id, deprecated, **kwargs):
         image_data = aliyun_image.get_compute_image(
             image_name=image_name,
             image_id=image_id,
-            is_deprecated=deprecated
+            status=status
         )
 
     echo_style(

--- a/aliyun_img_utils/aliyun_image.py
+++ b/aliyun_img_utils/aliyun_image.py
@@ -281,6 +281,7 @@ class AliyunImage(object):
     def delete_compute_image_in_regions(
         self,
         image_name,
+        delete_blob=False,
         force=False,
         regions=None
     ):
@@ -296,7 +297,11 @@ class AliyunImage(object):
             self.region = region
 
             try:
-                self.delete_compute_image(image_name, force=force)
+                self.delete_compute_image(
+                    image_name,
+                    delete_blob=delete_blob,
+                    force=force
+                )
             except Exception:
                 pass
 


### PR DESCRIPTION
- Add a longer default wait time with a configurable option
- Add lists for possible image states to the class
- By default search no all states when retrieving image
- Drop `--deprecated` in place of `--status` enum

In a follow on commit fix delete image bug.