### PR TITLE
Remove delete-blob option

### DIFF
--- a/aliyun_img_utils/aliyun_cli.py
+++ b/aliyun_img_utils/aliyun_cli.py
@@ -344,11 +344,6 @@ def create(
     required=True
 )
 @click.option(
-    '--delete-blob',
-    is_flag=True,
-    help='Also delete the image blob from storage bucket.'
-)
-@click.option(
     '--force',
     is_flag=True,
     help='Forcibly deletes the custom image, regardless of '
@@ -363,7 +358,7 @@ def create(
 )
 @add_options(shared_options)
 @click.pass_context
-def delete(context, image_name, delete_blob, force, regions, **kwargs):
+def delete(context, image_name, force, regions, **kwargs):
     """Delete a compute image and optionally the backing qcow2 blob."""
     process_shared_options(context.obj, kwargs)
     config_data = get_config(context.obj)
@@ -380,7 +375,6 @@ def delete(context, image_name, delete_blob, force, regions, **kwargs):
         )
 
         keyword_args = {
-            'delete_blob': delete_blob,
             'force': force
         }
 

--- a/aliyun_img_utils/aliyun_image.py
+++ b/aliyun_img_utils/aliyun_image.py
@@ -232,13 +232,11 @@ class AliyunImage(object):
     def delete_compute_image(
         self,
         image_name,
-        delete_blob=False,
         force=False
     ):
         """
-        Delete compute image in current region.
-
-        If delete_blob is True delete the backing storage blob.
+        Delete compute image in current region. This automatically deletes
+        the backing storage object.
         """
         try:
             image = self.get_compute_image(image_name=image_name)
@@ -263,23 +261,11 @@ class AliyunImage(object):
         self.wait_on_compute_image_delete(image['ImageId'])
         self.log.info(f'{image["ImageId"]} deleted in {self.region}')
 
-        if delete_blob:
-            oss_object = None
-            try:
-                device = image['DiskDeviceMappings']['DiskDeviceMapping'][0]
-                oss_object = device['ImportOSSObject']
-            except (IndexError, KeyError):
-                pass
-
-            if oss_object:
-                self.delete_storage_blob(oss_object)
-
         return True
 
     def delete_compute_image_in_regions(
         self,
         image_name,
-        delete_blob=False,
         force=False,
         regions=None
     ):
@@ -297,7 +283,6 @@ class AliyunImage(object):
             try:
                 self.delete_compute_image(
                     image_name,
-                    delete_blob=delete_blob,
                     force=force
                 )
             except Exception as error:

--- a/tests/test_aliyun_image.py
+++ b/tests/test_aliyun_image.py
@@ -167,9 +167,8 @@ class TestAliyunImage(object):
                 force_replace_image=True
             )
 
-    @patch.object(AliyunImage, 'delete_storage_blob')
     @patch.object(AliyunImage, 'get_compute_image')
-    def test_delete_compute_image(self, mock_get_image, mock_delete_tarball):
+    def test_delete_compute_image(self, mock_get_image):
         image = {
             'ImageId': 'm-123',
             'DiskDeviceMappings': {
@@ -187,14 +186,12 @@ class TestAliyunImage(object):
 
         assert self.image.delete_compute_image(
             'test-image',
-            delete_blob=True,
             force=True
         )
 
         # Image not exists
         assert self.image.delete_compute_image(
             'test-image',
-            delete_blob=True
         ) is False
 
     @patch.object(AliyunImage, 'delete_compute_image')


### PR DESCRIPTION
- When an image is deleted in Alibaba the disk image file (backing store) for
  the image is automatically deleted by the platform. The flag to force this
  deletion is superfluous.